### PR TITLE
Addition of school to get JetBrains products for learning

### DIFF
--- a/lib/domains/org/friendsseminary.txt
+++ b/lib/domains/org/friendsseminary.txt
@@ -1,0 +1,1 @@
+Friends Seminary


### PR DESCRIPTION
My school was not included in the list of schools JetBrains recognized when trying to apply for a free student license of IDEs, so it told me to do this.